### PR TITLE
modify curl images

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ spec:
     spec:
       containers:
       - name: ignored
-        image: tutum/curl
+        image: curlimages/curl
         command: ["/bin/sleep","infinity"]
 ```
 
@@ -482,7 +482,7 @@ spec:
     spec:
       containers:
       - name: sleep
-        image: tutum/curl
+        image: curlimages/curl
         command: ["/bin/sleep","infinity"]
         imagePullPolicy: IfNotPresent
 EOF
@@ -504,7 +504,7 @@ spec:
     spec:
       containers:
       - name: sleep
-        image: tutum/curl
+        image: curlimages/curl
         command: ["/bin/sleep","infinity"]
         imagePullPolicy: IfNotPresent
 EOF

--- a/manifests/sleep.yaml
+++ b/manifests/sleep.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: sleep
-        image: tutum/curl
+        image: curlimages/curl
         command: ["/bin/sleep","infinity"]
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
# Description
`tutum/curl` docker image is 404 Not found and seems to be currently unavailable.
So, modify the image used to execute the curl command on the sleep pod to `curlimages/curl`.

ref. 
https://hub.docker.com/r/tutum/curl/
https://hub.docker.com/r/curlimages/curl