### PR TITLE
Update mirror percent filed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1219,7 +1219,8 @@ spec:
       port:
         number: 8000
       subset: v2
-    mirror_percent: 100
+    mirrorPercentage:
+      value: 100.0
 EOF
 ```
 

--- a/manifests/virtualservice-mirror.yaml
+++ b/manifests/virtualservice-mirror.yaml
@@ -21,4 +21,5 @@ spec:
       port:
         number: 8000
       subset: v2
-    mirror_percent: 100
+    mirrorPercentage:
+      value: 100.0


### PR DESCRIPTION
# Description
Reflects the following about the traffic mirror percentage setting
* "mirror_percent" setting filed is deprecated in the latest version.
* Instead, "mirrorPercentage" is recommended.

# Reference
https://istio.io/latest/docs/tasks/traffic-management/mirroring/#mirroring-traffic-to-v2
https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute